### PR TITLE
Add new podcast label to css

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
     "manifest_version": 3,
     "name": "Spotify Podcast Banish",
     "description": "This Chrome extension banishes podcasts from the Spotify web player user interface.",
-    "version": "1.3",
+    "version": "1.4",
 
     "content_scripts": [
         {

--- a/styles.css
+++ b/styles.css
@@ -3,6 +3,7 @@ body {
 }
 
 section[aria-label='Shows to try'],
+section[aria-label='Show you might like'],
 section[aria-label='Episodes for you'] {
   aria-hidden: "true";
   display: none;

--- a/styles.css
+++ b/styles.css
@@ -3,7 +3,7 @@ body {
 }
 
 section[aria-label='Shows to try'],
-section[aria-label='Show you might like'],
+section[aria-label='Shows you might like'],
 section[aria-label='Episodes for you'] {
   aria-hidden: "true";
   display: none;


### PR DESCRIPTION
### Summary

I'm using the plugin and for some reason I'm getting both "Episodes for you" and "Shows you might like". In this PR, I'm adding the new label so it is also hidden.

<img width="419" alt="Screen Shot 2022-04-20 at 11 15 10 AM" src="https://user-images.githubusercontent.com/25408251/164296563-0f3835af-b647-45c8-a1a9-2890e7dbfc4c.png">
